### PR TITLE
Fix click version for CLI tests

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -78,13 +78,13 @@ files = [
 
 [[package]]
 name = "click"
-version = "8.1.8"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
-    {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 
 [package.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ typer       = { version = "^0.15.3", extras = ["all"] }
 jsonschema  = "^4.23.0"
 colorlog = "^6.8.0"
 jinja2 = ">=3.1,<4"
+click = "8.1.7"
 
 [tool.poetry.extras]
 # if you ever want to install just the CLI bits


### PR DESCRIPTION
## Summary
- pin `click` dependency to 8.1.7 for compatibility with Typer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684de8fcaba88328beab2d0eaf273faf