### PR TITLE
Fix yubikey ssh task success reporting

### DIFF
--- a/nextlevelapex/tasks/optional.py
+++ b/nextlevelapex/tasks/optional.py
@@ -24,7 +24,7 @@ def setup_yubikey_ssh_task(ctx: Dict) -> TaskResult:
 
     return TaskResult(
         name="YubiKey SSH Setup",
-        success=True,
+        success=success,
         changed=success and not dry_run,
         messages=messages,
     )

--- a/tests/test_optional_tasks.py
+++ b/tests/test_optional_tasks.py
@@ -1,0 +1,36 @@
+import pytest
+
+from nextlevelapex.core.task import Severity, TaskResult
+from nextlevelapex.tasks.optional import setup_yubikey_ssh_task
+
+
+class DummyCtx(dict):
+    def __init__(self, dry_run=True):
+        super().__init__()
+        self["dry_run"] = dry_run
+        self["config"] = {}
+
+
+@pytest.mark.parametrize(
+    "mock_return,dry_run,expect_changed",
+    [
+        (True, False, True),
+        (True, True, False),
+        (False, False, False),
+        (False, True, False),
+    ],
+)
+def test_setup_yubikey_ssh_task(monkeypatch, mock_return, dry_run, expect_changed):
+    monkeypatch.setattr(
+        "nextlevelapex.tasks.optional.setup_yubikey_ssh", lambda config, dry_run: mock_return
+    )
+    ctx = DummyCtx(dry_run=dry_run)
+    result: TaskResult = setup_yubikey_ssh_task(ctx)
+
+    assert isinstance(result, TaskResult)
+    assert result.success == mock_return
+    assert result.changed == expect_changed
+    if not mock_return:
+        assert any(sev == Severity.WARNING for sev, _ in result.messages)
+    else:
+        assert result.messages == []


### PR DESCRIPTION
## Summary
- fix `setup_yubikey_ssh_task` return status
- add tests for yubikey ssh wrapper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684decafc9d08328a54b7683898f69d6