### PR TITLE
chore: mark S18 done after PR #128 merge

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -27,7 +27,7 @@ See [milestones.md](milestones.md) for milestone definitions and mapping rules.
 | S15 | Performance + Accessibility Hardening | backlog | perf | M3 | — | [S15](../sprints/S15/) |
 | S16 | Operator-Grade QA Megasuite | backlog | test | M3 | — | [S16](../sprints/S16/) |
 | S17 | URL Sync Loop Hardening | done | bug | M3 | [#126](https://github.com/Doogie201/NextLevelApex/pull/126) | [S17](../sprints/S17/) |
-| S18 | Release Certification v2 | in-review | chore | M3 | [#128](https://github.com/Doogie201/NextLevelApex/pull/128) | [S18](../sprints/S18/) |
+| S18 | Release Certification v2 | done | chore | M3 | [#128](https://github.com/Doogie201/NextLevelApex/pull/128) | [S18](../sprints/S18/) |
 | S19 | Worktree + Poetry Guardrails v2 | backlog | chore | M3 | — | [S19](../sprints/S19/) |
 | S20 | Governance: DoD + Stop Conditions | backlog | docs | M4 | — | [S20](../sprints/S20/) |
 | S21 | Operator Execution Safety System (OESS) | backlog | security | M4 | — | [S21](../sprints/S21/) |

--- a/docs/sprints/README.md
+++ b/docs/sprints/README.md
@@ -30,7 +30,7 @@ Quick links to each sprint's documentation folder.
 | S15 | [S15/](S15/) | backlog |
 | S16 | [S16/](S16/) | backlog |
 | S17 | [S17/](S17/) | done |
-| S18 | [S18/](S18/) | in-review |
+| S18 | [S18/](S18/) | done |
 | S19 | [S19/](S19/) | backlog |
 | S20 | [S20/](S20/) | backlog |
 | S21 | [S21/](S21/) | backlog |

--- a/docs/sprints/S18/README.md
+++ b/docs/sprints/S18/README.md
@@ -4,7 +4,7 @@
 |-------|-------|
 | Sprint ID | `S18` |
 | Name | Release Certification v2 |
-| Status | in-review |
+| Status | done |
 | Category | chore |
 | Milestone | M3 |
 | Baseline SHA | `c21bf51cb0e54832c30c268e51b9bf0da560e116` |
@@ -57,7 +57,7 @@ The comprehensive cert receipt JSON is committed at [`evidence/AT05_cert_receipt
 |------|--------|--------|
 | `npm run build` | PASS | Next.js 16.1.6 compiled in 1.5s, TypeScript clean |
 | `npm run lint` | PASS | eslint clean |
-| `npm test` | PASS | 40 files, 172 tests, 0 failures |
+| `npm test` | PASS | 40 files, 173 tests, 0 failures |
 
 ## Diff Stats
 
@@ -76,4 +76,4 @@ The comprehensive cert receipt JSON is committed at [`evidence/AT05_cert_receipt
 
 - [x] All ATs pass with receipts.
 - [x] Gates pass (build/lint/test EXIT 0).
-- [ ] PR merged via squash merge.
+- [x] PR merged via squash merge.

--- a/docs/sprints/S18/evidence/AT05_cert_receipt.json
+++ b/docs/sprints/S18/evidence/AT05_cert_receipt.json
@@ -21,7 +21,7 @@
     },
     "test": {
       "status": "PASS",
-      "detail": "40 files, 172 tests, 0 failures (Vitest 2.1.9)"
+      "detail": "40 files, 173 tests, 0 failures (Vitest 2.1.9)"
     }
   },
   "acceptance_tests": {


### PR DESCRIPTION
## Summary

- Mark S18 status as `done` in sprint README, backlog index, and sprints index after PR #128 merge
- Check final DoD box (PR merged via squash merge)
- Update test count to 173 (reflects added FETCH_ERROR test)

Docs-only change, no code modifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)