### PR TITLE
chore: mark S24 done after PR #130 merge

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -33,7 +33,7 @@ See [milestones.md](milestones.md) for milestone definitions and mapping rules.
 | S21 | Operator Execution Safety System (OESS) | backlog | security | M4 | — | [S21](../sprints/S21/) |
 | S22 | Backlog Index Layout | done | docs | M1 | [#124](https://github.com/Doogie201/NextLevelApex/pull/124) | [S22](../sprints/S22/) |
 | S23 | Governance Gates v1 | done | devops | M4 | [#125](https://github.com/Doogie201/NextLevelApex/pull/125) | [S23](../sprints/S23/) |
-| S24 | S18 Cert Validation Hardening (Harness-Based) | in-progress | test | M3 | — | [S24](../sprints/S24/) |
+| S24 | S18 Cert Validation Hardening (Harness-Based) | done | test | M3 | [#130](https://github.com/Doogie201/NextLevelApex/pull/130) | [S24](../sprints/S24/) |
 
 ## Renumbering Note
 

--- a/docs/sprints/README.md
+++ b/docs/sprints/README.md
@@ -36,6 +36,6 @@ Quick links to each sprint's documentation folder.
 | S21 | [S21/](S21/) | backlog |
 | S22 | [S22/](S22/) | done |
 | S23 | [S23/](S23/) | done |
-| S24 | [S24/](S24/) | in-progress |
+| S24 | [S24/](S24/) | done |
 
 See the [master backlog](../backlog/README.md) for objectives, categories, milestones, and PR links.


### PR DESCRIPTION
## Summary
- Mark S24 as `done` in sprint index and backlog after PR #130 merge
- Add PR #130 link to backlog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)