### PR TITLE
fix: restore default cli dependency contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ cd NextLevelApex
 poetry install
 ```
 
+Plain `poetry install` is the canonical install contract for this repo. The `nlx` CLI
+and its Typer runtime are part of the default dependency set, so no optional CLI extra
+is required or supported for standard operator and CI workflows.
+
 ## Quickstart
 
 List commands:
@@ -168,6 +172,8 @@ Without this, you will see:
 - `ModuleNotFoundError` for dependencies:
   - Run `poetry install` then use `poetry run ...` or activate Poetry's environment.
   - In a git worktree, you must run `poetry install` in each worktree separately.
+  - If plain `poetry install` does not make `poetry run nlx --help` work, treat that as a
+    packaging or lockfile contract bug, not as a missing optional extra.
 - `Warning: 'nlx' is an entry point ... not installed as a script`:
   - Run `poetry install` to register the entrypoint.
 - `install-sudoers` cannot verify `includedir`:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1629,10 +1629,7 @@ pyyaml = "*"
 [package.extras]
 dev = ["doc8", "flake8", "flake8-import-order", "rstcheck[sphinx]", "sphinx"]
 
-[extras]
-cli = ["typer"]
-
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "757789c2df856720cd31bdea2bd9b8dcd450602630c49c46a122e01ef73ef2ee"
+content-hash = "d909d72d45fad8a61e1e336229dfaae8263e20c7d93eb9716e689418957824fa"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ include  = [
 python      = "^3.11"
 # Typer/Click combo pinned to avoid the help-rendering regression you hit
 click       = "<8.2.0"
+# `nlx` is a first-class repo runtime, so Typer must stay in the default install set.
 typer       = "~0.12.5"
 rich        = "^14"
 jsonschema  = "^4.23.0"
@@ -50,9 +51,6 @@ fastapi = "^0.129.0"
 uvicorn = "^0.41.0"
 pydantic = "^2.12.5"
 websockets = "^16.0"
-
-[tool.poetry.extras]
-cli = ["typer"]
 
 [tool.poetry.scripts]
 nlx = "nextlevelapex.main2:app"

--- a/tests/core/test_dependency_governance.py
+++ b/tests/core/test_dependency_governance.py
@@ -69,6 +69,9 @@ def test_cli_runtime_dependencies_are_part_of_default_install_contract():
 def test_poetry_lock_keeps_cli_runtime_unconditional():
     project_root = Path(__file__).parent.parent.parent
     poetry_lock = (project_root / "poetry.lock").read_text()
+    poetry_lock_data = tomllib.loads(poetry_lock)
+    lock_extras = poetry_lock_data.get("extras", {})
+    extra_values = {dep_name for values in lock_extras.values() for dep_name in values}
 
     def package_block(name: str) -> str:
         match = re.search(
@@ -82,5 +85,8 @@ def test_poetry_lock_keeps_cli_runtime_unconditional():
     typer_block = package_block("typer")
     shellingham_block = package_block("shellingham")
 
+    assert "cli" not in lock_extras
+    assert "typer" not in extra_values
+    assert "shellingham" not in extra_values
     assert 'markers = "extra == \\"cli\\""' not in typer_block
     assert 'markers = "extra == \\"cli\\""' not in shellingham_block

--- a/tests/core/test_dependency_governance.py
+++ b/tests/core/test_dependency_governance.py
@@ -1,4 +1,6 @@
 import ast
+import re
+import tomllib
 from pathlib import Path
 
 from typer.testing import CliRunner
@@ -48,3 +50,37 @@ def test_no_shell_true_in_source_code():
                 )
 
     assert not violations, f"Found restricted 'shell=True' invocations in: {violations}"
+
+
+def test_cli_runtime_dependencies_are_part_of_default_install_contract():
+    project_root = Path(__file__).parent.parent.parent
+    pyproject = tomllib.loads((project_root / "pyproject.toml").read_text())
+
+    poetry = pyproject["tool"]["poetry"]
+    dependencies = poetry["dependencies"]
+    extras = poetry.get("extras", {})
+    extra_values = {dep_name for values in extras.values() for dep_name in values}
+
+    assert poetry["scripts"]["nlx"] == "nextlevelapex.main2:app"
+    assert "typer" in dependencies
+    assert "typer" not in extra_values
+
+
+def test_poetry_lock_keeps_cli_runtime_unconditional():
+    project_root = Path(__file__).parent.parent.parent
+    poetry_lock = (project_root / "poetry.lock").read_text()
+
+    def package_block(name: str) -> str:
+        match = re.search(
+            rf'\[\[package\]\]\nname = "{name}"\n.*?(?=\n\[\[package\]\]\n|\Z)',
+            poetry_lock,
+            re.S,
+        )
+        assert match, f"package {name} not found in poetry.lock"
+        return match.group(0)
+
+    typer_block = package_block("typer")
+    shellingham_block = package_block("shellingham")
+
+    assert 'markers = "extra == \\"cli\\""' not in typer_block
+    assert 'markers = "extra == \\"cli\\""' not in shellingham_block


### PR DESCRIPTION
## Summary
- remove the stale optional `cli` extra that was contradicting the repo's default CLI runtime contract
- regenerate `poetry.lock` under the corrected contract so `typer` remains installed on plain `poetry install`
- add dependency-governance coverage that fails if `typer` or `shellingham` drift behind `extra == "cli"` again
- document that plain `poetry install` is the canonical install path for `nlx`

## Root Cause
Dependency PRs were regenerating `poetry.lock` with `typer` and `shellingham` behind `extra == "cli"`, while CI still installs with plain `poetry install --no-interaction --no-ansi` and immediately runs `poetry run nlx ...`.

## Evidence
- `poetry run nlx --help`
- `poetry run nlx --dry-run --no-reports --task Mise --task Security`
- `poetry run pytest -q tests/core/test_dependency_governance.py tests/test_cli_help.py tests/test_main_entrypoint_shim.py`
- `poetry run pytest -q --maxfail=1 --disable-warnings --cov=nextlevelapex --cov-branch --cov-report=xml:coverage.xml --cov-report=term --cov-report=html:htmlcov`
- `poetry run coverage report --rcfile=.coveragerc --fail-under=40`
- `poetry run ruff check .`
- `poetry run black --check .`
- `poetry run isort --check-only .`
- `poetry run mypy .`
